### PR TITLE
GitHub Actions上でビルドを回すように

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,39 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Copy artifacts
+        run: |
+          rm -rf public
+          mkdir -p public
+          cp -r docs/.vitepress/dist/* public
+
+      - name: Deploy to built branch
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git checkout -b built
+          git add .
+          git commit -m "Automatic build and deploy from GitHub Actions"
+          git push -f origin built


### PR DESCRIPTION
VitePressのビルドはメモリをかなり消費するようで、NeoShowcase上でのビルドは難しい
代わりにGitHub Actions上でビルドして、成果物を`built`ブランチにアップロードした上でそれを静的にNeoShowcase上から配信する (`main`ブランチのpushのたびにデプロイする用に設定しているが、そこら辺は柔軟に対応)

成果物は`public`ディレクトリに配置されるので、それをNeoShowcaseで配信 (no build) すればOKです