### PR TITLE
Chapter0のVSCode周りの説明を修正

### DIFF
--- a/docs/text/chapter-0/enviroment/mac.md
+++ b/docs/text/chapter-0/enviroment/mac.md
@@ -44,7 +44,7 @@ next: {link: '/text/chapter-0/guidance', text: 講習会ガイダンス'}
 ![](https://md.trap.jp/uploads/upload_8a51ad57ec7b6d396cb610c9bbb17040.png)
 
 
-6. `⌘+Shift+X` を押して、出てきた画面に `Japanese` と入力。 `Japanese Language Pack for Visual Studio Code` をインストールする。インストール完了後、右下の `Install and Restart` を押して VSCode を再起動する。
+6. `⌘+Shift+X` を押して、出てきた画面に `Japanese` と入力。 `Japanese Language Pack for Visual Studio Code` をインストールする。インストール完了後、右下の `Change Language and Restart` を押して VSCode を再起動する。
 ![](https://md.trap.jp/uploads/upload_6c5cfaf6aadcc679382c966d4bccb753.png)
 
 5. 日本語でVSCode が表示されるようになったら :vscode: スタンプをつける

--- a/docs/text/chapter-0/enviroment/mac.md
+++ b/docs/text/chapter-0/enviroment/mac.md
@@ -60,15 +60,7 @@ next: {link: '/text/chapter-0/guidance', text: 講習会ガイダンス'}
 4. `⌘` + `,` で設定を開く。下記画像の赤丸で囲んだ部分を押して `settings.json` を開く。
 ![](https://md.trap.jp/uploads/upload_bbdd65cb92c5c57bb38f797676aaea8f.png)
 
-5. `"cpp": ` で始まる行を探して、`g++` を `clang++` に置き換える。
-
-```diff
-- "cpp": "cd $dir && g++ $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
-+ "cpp": "cd $dir && clang++ -std=c++17 $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
-```
-
-::: tip
-なかった場合は、一番最後の行の1つ前の行（ `}` の前！）に次のコードを追加してください。その前の行に `,` がなかったら追加してください！
+5. もし`"cpp": `で始まる行がなければ、一番最後の行の1つ前の行（ `}` の前！）に次のコードを追加する。その前の行に `,` がなかったら追加する。
 
 ```
 "code-runner.executorMap": {
@@ -77,6 +69,15 @@ next: {link: '/text/chapter-0/guidance', text: 講習会ガイダンス'}
 ```
 
 ![](https://md.trap.jp/uploads/upload_6123c7ce669910790a06b98cc664b827.png)
+
+::: tip
+
+もしすでに`"cpp": ` で始まる行があった場合、以下のように`g++` を `clang++` に置き換える。
+
+```diff
+- "cpp": "cd $dir && g++ $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
++ "cpp": "cd $dir && clang++ -std=c++17 $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
+```
 
 :::
 

--- a/docs/text/chapter-0/enviroment/windows.md
+++ b/docs/text/chapter-0/enviroment/windows.md
@@ -72,7 +72,7 @@ https://learn.microsoft.com/ja-jp/windows/wsl/install-manual
 3. `Japanese` と入力し、 `Japanese Language Pack for Visual Studio Code` をインストール。
 ![](https://md.trap.jp/uploads/upload_b54bb733b3bf68010e033d30f2bf57c2.png)
 
-4. VSCode の右下「Install and Restart」を押してインストール。
+4. VSCode の右下「Change Language and Restart」を押してインストール。
 
 5. もう一度、 `Ctrl` + `Shift` + `X` を押す
 

--- a/docs/text/chapter-0/enviroment/windows.md
+++ b/docs/text/chapter-0/enviroment/windows.md
@@ -100,15 +100,7 @@ https://learn.microsoft.com/ja-jp/windows/wsl/install-manual
 4. `Ctrl` + `,` で設定を開く。下記画像の赤丸で囲んだ部分を押して `settings.json` を開く。
 ![](https://md.trap.jp/uploads/upload_bbdd65cb92c5c57bb38f797676aaea8f.png)
 
-5. `"cpp": ` で始まる行を探して、`g++` を `clang++` に置き換える。
-
-```diff
-- "cpp": "cd $dir && g++ $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
-+ "cpp": "cd $dir && clang++ -std=c++17 $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
-```
-
-::: tip
-なかった場合は、一番最後の行の1つ前の行（ `}` の前！）に次のコードを追加してください。その前の行に `,` がなかったら追加してください！
+5. もし`"cpp": `で始まる行がなければ、一番最後の行の1つ前の行（ `}` の前！）に次のコードを追加する。その前の行に `,` がなかったら追加する。
 
 ```
 "code-runner.executorMap": {
@@ -118,8 +110,16 @@ https://learn.microsoft.com/ja-jp/windows/wsl/install-manual
 
 ![](https://md.trap.jp/uploads/upload_6123c7ce669910790a06b98cc664b827.png)
 
-:::
+::: tip
 
+もしすでに`"cpp": ` で始まる行があった場合、以下のように`g++` を `clang++` に置き換える。
+
+```diff
+- "cpp": "cd $dir && g++ $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
++ "cpp": "cd $dir && clang++ -std=c++17 $fileName -o $fileNameWithoutExt && $dir$fileNameWithoutExt",
+```
+
+:::
 
 6. `"code-runner.executorMap": {` の行の前に `"code-runner.runInTerminal": true,` を書く（コピペ推奨！！）
 


### PR DESCRIPTION
- VSCodeで、config.jsonにclang++の設定を書くとき、`"cpp": `から始まる行がない、という質問が多かったため、TIP欄と内容を入れ替えた
- VSCodeのエラーメッセージが変わっているようだったので修正した