### PR TITLE
6.2 メソッドにおけるコード例の誤植修正

### DIFF
--- a/docs/text/chapter-6/method.md
+++ b/docs/text/chapter-6/method.md
@@ -59,7 +59,7 @@ int main() {
     Member zer0star{"zer0-star", "22BXXXXX", 2};
 
     zer0star.updateGrade(1);
-    cout << yukikurage.grade << endl;
+    cout << zer0star.grade << endl;
 }
 ```
 


### PR DESCRIPTION
インスタンス更新のコード例で`zer0star`となるべき箇所が`yukikurage`となっていたので修正した。